### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
+- PUPPET_VERSION=2.7.23
 - PUPPET_VERSION=3.3.2
 notifications:
 email: false
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,7 @@ describe 'citrix_unix' do
 
     it 'should fail' do
       expect {
-        should include_class('citrix_unix')
+        should contain_class('citrix_unix')
       }.to raise_error(Puppet::Error,/ctx_patch_base_path must be set to a absolute path/)
     end
   end
@@ -51,7 +51,7 @@ describe 'citrix_unix' do
 
     it 'should fail' do
       expect {
-        should include_class('citrix_unix')
+        should contain_class('citrix_unix')
       }.to raise_error(Puppet::Error,/citrix_unix is supported on osfamily Solaris/)
     end
   end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
